### PR TITLE
Rely on package mark released with Puppet 6.13.0

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 # @param manage_repo Manage the odoo reposiroty
 # @param manage_package Manage the odoo package
 # @param package_ensure Ensure value for the odoo package
+# @param package_mark Mark value for the odoo package
 #
 # @param admin_passwd Password that allows database operations
 # @param csv_internal_sep Legacy (now unused)
@@ -82,7 +83,8 @@ class odoo (
   Boolean $manage_repo    = true,
   Boolean $manage_package = true,
 
-  String  $package_ensure = 'present',
+  String                         $package_ensure = 'present',
+  Optional[Enum['hold', 'none']] $package_mark   = undef,
 
   Optional[Sensitive]                      $admin_passwd           = undef,
   Optional[String]                         $csv_internal_sep       = undef,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -7,6 +7,7 @@ class odoo::package {
   if $odoo::manage_package {
     package { 'odoo':
       ensure => $odoo::package_ensure,
+      mark   => $odoo::package_mark,
     }
   }
 }


### PR DESCRIPTION
This is backward incompatible with previous versions of Puppet.  We do
not really care since the module is not yet published.

Details:
https://puppet.com/docs/puppet/latest/release_notes_puppet.html#mark-property-added-as-alternative-to-held-value-for-ensure