### PR TITLE
Use wkhtmltox 0.12.5 with Odoo 13

### DIFF
--- a/manifests/wkhtmltox.pp
+++ b/manifests/wkhtmltox.pp
@@ -2,9 +2,20 @@
 #
 # @api private
 class odoo::wkhtmltox {
+  include odoo
+
   assert_private()
 
-  $wkhtmltox_version = '0.12.1.4'
+  $wkhtmltox_version = $odoo::version ? {
+    '13.0'  => '0.12.5',
+    default => '0.12.1.4',
+  }
+
+  $wkhtmltox_url = $odoo::version ? {
+    '13.0'  => "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${wkhtmltox_version}/wkhtmltox_${wkhtmltox_version}-1.${facts.get('os.distro.codename')}_${facts.get('architecture')}.deb",
+    default => "https://builds.wkhtmltopdf.org/${wkhtmltox_version}/wkhtmltox_${wkhtmltox_version}-1.${facts.get('os.distro.codename')}_${facts.get('architecture')}.deb",
+  }
+
   $wkhtmltox_dependencies = [
     'xfonts-75dpi',
     'xfonts-base',
@@ -14,7 +25,7 @@ class odoo::wkhtmltox {
     ensure => present,
     user   => 'root',
     group  => 'root',
-    source => "https://builds.wkhtmltopdf.org/${wkhtmltox_version}/wkhtmltox_${wkhtmltox_version}-1.${facts.get('os.distro.codename')}_${facts.get('architecture')}.deb",
+    source => $wkhtmltox_url,
   }
 
   package { $wkhtmltox_dependencies:


### PR DESCRIPTION
Previous versions use a previous version of wkhtmltox.  Both versions
are not available through the same mirrors.