### PR TITLE
Improve databases listing

### DIFF
--- a/files/databases-list.py
+++ b/files/databases-list.py
@@ -1,12 +1,13 @@
 import json
+from collections import OrderedDict
 
 res = {}
 
 for dbname in odoo.service.db.list_dbs(True):
-    res[dbname] = {}
+    res[dbname] = OrderedDict()
     registry = odoo.registry(dbname)
     with registry.cursor() as cr:
-        cr.execute("SELECT key, value FROM ir_config_parameter WHERE key IN ('database.create_date', 'database.enterprise_code', 'database.expiration_date', 'database.expiration_reason', 'web.base.url')")
+        cr.execute("SELECT key, value FROM ir_config_parameter WHERE key IN ('database.create_date', 'database.enterprise_code', 'database.expiration_date', 'database.expiration_reason', 'web.base.url') ORDER BY key")
         for line in cr.fetchall():
             res[dbname][line[0]] = line[1]
 

--- a/files/databases-list.py
+++ b/files/databases-list.py
@@ -1,0 +1,13 @@
+import json
+
+res = {}
+
+for dbname in odoo.service.db.list_dbs(True):
+    res[dbname] = {}
+    registry = odoo.registry(dbname)
+    with registry.cursor() as cr:
+        cr.execute("SELECT key, value FROM ir_config_parameter WHERE key IN ('database.create_date', 'database.enterprise_code', 'database.expiration_date', 'database.expiration_reason', 'web.base.url')")
+        for line in cr.fetchall():
+            res[dbname][line[0]] = line[1]
+
+print(json.dumps(res))

--- a/tasks/databases_list.json
+++ b/tasks/databases_list.json
@@ -1,3 +1,4 @@
 {
-  "description": "List odoo databases"
+  "description": "List odoo databases",
+  "files": ["odoo/files/databases-list.py"]
 }

--- a/tasks/databases_list.sh
+++ b/tasks/databases_list.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-ls ~odoo/.local/share/Odoo/filestore
+/usr/bin/odoo shell --config=/etc/odoo/odoo.conf --no-http --workers=0 < ${PT__installdir}/odoo/files/databases-list.py


### PR DESCRIPTION
Instead of a bare list of available databases, output a JSON payload
usable in choria playbooks / bolt plans with extra information attached
to each database name:

  * its creation date;
  * its registration code;
  * its expiration date;
  * its expiration reason;
  * its url.

```json
{
  "production": {
    "database.create_date": "2020-06-16 23:14:43",
    "database.enterprise_code": "M1234567890123",
    "database.expiration_date": "2020-08-29 00:00:00",
    "database.expiration_reason": "renewal",
    "web.base.url": "http://example.com"
  },
  "sandbox": {
    "database.create_date": "2020-05-07 00:38:23",
    "database.expiration_date": "2020-09-11 21:55:32",
    "database.expiration_reason": "trial",
    "web.base.url": "http://sandbox.example.com"
  }
}
```