### PR TITLE
Rework module tasks

### DIFF
--- a/files/database-backup.py
+++ b/files/database-backup.py
@@ -1,0 +1,6 @@
+import os
+
+odoo.tools.config['list_db'] = True
+
+with open(os.environ['PT_filename']) as t:
+    odoo.service.db.dump_db(os.environ['PT_name'], t, os.environ['PT_format'])

--- a/files/database-delete.py
+++ b/files/database-delete.py
@@ -1,0 +1,5 @@
+import os
+
+odoo.tools.config['list_db'] = True
+
+odoo.service.db.exp_drop(os.environ['PT_name'])

--- a/files/database-duplicate.py
+++ b/files/database-duplicate.py
@@ -1,0 +1,4 @@
+import os
+
+odoo.tools.config['list_db'] = True
+odoo.service.db.exp_duplicate_database(os.environ['PT_oldname'], os.environ['PT_newname'])

--- a/files/database-rename.py
+++ b/files/database-rename.py
@@ -1,0 +1,4 @@
+import os
+
+odoo.tools.config['list_db'] = True
+odoo.service.db.exp_rename(os.environ['PT_oldname'], os.environ['PT_newname'])

--- a/files/database-restore.py
+++ b/files/database-restore.py
@@ -1,0 +1,4 @@
+import os
+
+odoo.tools.config['list_db'] = True
+odoo.service.db.exp_restore(os.environ['PT_name'], os.environ['PT_filename'], os.environ['PT_copy'].lower() in ('yes', 'true', 't', 'y', '1'))

--- a/tasks/database_backup.json
+++ b/tasks/database_backup.json
@@ -9,6 +9,12 @@
     "filename": {
       "description": "Remote filename for the backup",
       "type": "String"
+    },
+    "format": {
+      "description": "Backup format",
+      "type": "Enum['zip']",
+      "default": "zip"
     }
-  }
+  },
+  "files": ["odoo/files/database-backup.py"]
 }

--- a/tasks/database_backup.sh
+++ b/tasks/database_backup.sh
@@ -2,24 +2,4 @@
 
 set -e
 
-if [ -f "${PT_filename}" ]; then
-	echo "The backup ${PT_filename} MUST NOT exist" >&2
-	exit 1
-fi
-
-if [ ! -d ~odoo/.local/share/Odoo/filestore/"${PT_name}" ]; then
-	echo "The database ${PT_name} MUST exist" >&2
-	exit 1
-fi
-
-TMPDIR=`mktemp -d`
-
-cp -R ~odoo/.local/share/Odoo/filestore/"${PT_name}" "${TMPDIR}/filestore"
-find "${TMPDIR}/filestore" -type d -empty -delete
-sudo -u postgres pg_dump --no-owner "${PT_name}" > "${TMPDIR}/dump.sql"
-(
-	cd "$TMPDIR"
-	zip -qr "${PT_filename}" filestore dump.sql
-)
-
-rm -r "${TMPDIR}"
+/usr/bin/odoo shell --config=/etc/odoo/odoo.conf --no-http --workers=0 < ${PT__installdir}/odoo/files/database-backup.py

--- a/tasks/database_delete.json
+++ b/tasks/database_delete.json
@@ -6,5 +6,6 @@
       "description": "Odoo database name",
       "type": "String"
     }
-  }
+  },
+  "files": ["odoo/files/database-delete.py"]
 }

--- a/tasks/database_delete.sh
+++ b/tasks/database_delete.sh
@@ -2,7 +2,4 @@
 
 set -e
 
-systemctl stop odoo
-sudo -u postgres dropdb "$PT_name"
-rm -r ~odoo/.local/share/Odoo/filestore/"$PT_name"
-systemctl start odoo
+/usr/bin/odoo shell --config=/etc/odoo/odoo.conf --no-http --workers=0 < ${PT__installdir}/odoo/files/database-delete.py

--- a/tasks/database_duplicate.json
+++ b/tasks/database_duplicate.json
@@ -1,0 +1,15 @@
+{
+  "description": "Duplicate an odoo database",
+  "input_method": "environment",
+  "parameters": {
+    "oldname": {
+      "description": "Name of the existing Odoo database",
+      "type": "String"
+    },
+    "newname": {
+      "description": "Name of the new Odoo database",
+      "type": "String"
+    }
+  },
+  "files": ["odoo/files/database-duplicate.py"]
+}

--- a/tasks/database_duplicate.sh
+++ b/tasks/database_duplicate.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+/usr/bin/odoo shell --config=/etc/odoo/odoo.conf --no-http --workers=0 < ${PT__installdir}/odoo/files/database-duplicate.py

--- a/tasks/database_rename.json
+++ b/tasks/database_rename.json
@@ -10,5 +10,6 @@
       "description": "New database name (must not exist)",
       "type": "String"
     }
-  }
+  },
+  "files": ["odoo/files/database-rename.py"]
 }

--- a/tasks/database_rename.sh
+++ b/tasks/database_rename.sh
@@ -2,20 +2,4 @@
 
 set -e
 
-old_path=~odoo/.local/share/Odoo/filestore/"$PT_oldname"
-new_path=~odoo/.local/share/Odoo/filestore/"$PT_newname"
-
-if [ ! -d "$old_path" ]; then
-	echo "Old filestore MUST exist" >&2
-	exit 1
-fi
-
-if [ -e "$new_path" ]; then
-	echo "New filestore MUST NOT exist" >&2
-	exit 1
-fi
-
-systemctl stop odoo
-sudo -u postgres psql template1 -c '\set ON_ERROR_STOP on' -c "ALTER DATABASE \"$PT_oldname\" RENAME TO \"$PT_newname\";"
-mv ~odoo/.local/share/Odoo/filestore/"$PT_oldname" ~odoo/.local/share/Odoo/filestore/"$PT_newname"
-systemctl start odoo
+/usr/bin/odoo shell --config=/etc/odoo/odoo.conf --no-http --workers=0 < ${PT__installdir}/odoo/files/database-rename.py

--- a/tasks/database_restore.json
+++ b/tasks/database_restore.json
@@ -9,6 +9,12 @@
     "filename": {
       "description": "Remote filename for the backup",
       "type": "String"
+    },
+    "copy": {
+      "description": "",
+      "type": "Boolean",
+      "default": true
     }
-  }
+  },
+  "files": ["odoo/files/database-restore.py"]
 }

--- a/tasks/database_restore.sh
+++ b/tasks/database_restore.sh
@@ -2,25 +2,4 @@
 
 set -e
 
-if [ ! -f "${PT_filename}" ]; then
-	echo "The backup ${PT_filename} MUST exist" >&2
-	exit 1
-fi
-
-if [ -d ~odoo/.local/share/Odoo/filestore/"${PT_name}" ]; then
-	echo "The database ${PT_name} MUST NOT exist" >&2
-	exit 1
-fi
-
-TMPDIR=`mktemp -d`
-
-(
-	cd "$TMPDIR"
-	unzip "${PT_filename}"
-)
-chown -R odoo:odoo "${TMPDIR}/filestore"
-mv "${TMPDIR}/filestore" ~odoo/.local/share/Odoo/filestore/"${PT_name}"
-sudo -u postgres createdb -Oodoo -Eunicode "${PT_name}"
-sudo -u postgres psql "${PT_name}" < "${TMPDIR}/dump.sql"
-
-rm -r "${TMPDIR}"
+/usr/bin/odoo shell --config=/etc/odoo/odoo.conf --no-http --workers=0 < ${PT__installdir}/odoo/files/database-restore.py


### PR DESCRIPTION
Rely on `odoo shell` to execute python code built-into odoo to manage the
odoo databases instead of using custom shell code.

This is intended to lower the efforts needed to maintain these tasks,
with the drawback that different odoo versions will produce slyghtly
different results.