### PR TITLE
Explicitely output JSON

### DIFF
--- a/files/list-users.py
+++ b/files/list-users.py
@@ -8,4 +8,4 @@ else:
 
 users = env['res.users'].search(search_filter)
 
-print(json.dumps(users.mapped('login')))
+print(json.dumps({'users': users.mapped('login')}))


### PR DESCRIPTION
This allows Bolt to parse the response as JSON and provide a usable data
structure instead of returning a raw string that looks like an array of
strings (`["foo", "bar"]`).