### PR TITLE
Open file for writing

### DIFF
--- a/files/database-backup.py
+++ b/files/database-backup.py
@@ -2,5 +2,5 @@ import os
 
 odoo.tools.config['list_db'] = True
 
-with open(os.environ['PT_filename']) as t:
+with open(os.environ['PT_filename'], mode='w+b') as t:
     odoo.service.db.dump_db(os.environ['PT_name'], t, os.environ['PT_format'])


### PR DESCRIPTION
Dumping a database need a file descriptor on a file opened for writing…
Default is reading.

Fix that!