### PR TITLE
Fix module dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,8 +13,16 @@
       "version_requirement": ">= 4.0.0 < 5.0.0"
     },
     {
+      "name": "puppetlabs-apt",
+      "version_requirement": "< 8.0.0"
+    },
+    {
       "name": "puppetlabs-inifile",
       "version_requirement": ">= 4.0.0 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.13.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -36,7 +44,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
The `apt` and `stdlib` dependencies are missing.  Also, we do not support Puppet 5: the `get()` function was added in Puppet 6.