### PR TITLE
Fix installation of wkhtmltopdf

### DIFF
--- a/manifests/wkhtmltox.pp
+++ b/manifests/wkhtmltox.pp
@@ -35,9 +35,7 @@ class odoo::wkhtmltox {
     source => $wkhtmltox_url,
   }
 
-  package { $wkhtmltox_dependencies:
-    ensure => installed,
-  }
+  ensure_packages($wkhtmltox_dependencies, { ensure => installed })
 
   package { 'wkhtmltox':
     ensure   => installed,

--- a/manifests/wkhtmltox.pp
+++ b/manifests/wkhtmltox.pp
@@ -6,20 +6,25 @@ class odoo::wkhtmltox {
 
   assert_private()
 
-  $wkhtmltox_version = $odoo::version ? {
-    '13.0'  => '0.12.5',
-    default => '0.12.1.4',
-  }
+  $wkhtmltox_version = '0.12.5'
+  $wkhtmltox_url = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${wkhtmltox_version}/wkhtmltox_${wkhtmltox_version}-1.${facts.get('os.distro.codename')}_${facts.get('architecture')}.deb"
 
-  $wkhtmltox_url = $odoo::version ? {
-    '13.0'  => "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${wkhtmltox_version}/wkhtmltox_${wkhtmltox_version}-1.${facts.get('os.distro.codename')}_${facts.get('architecture')}.deb",
-    default => "https://builds.wkhtmltopdf.org/${wkhtmltox_version}/wkhtmltox_${wkhtmltox_version}-1.${facts.get('os.distro.codename')}_${facts.get('architecture')}.deb",
+  $wkhtmltox_dependencies = $facts.get('os.name') ? {
+    'Debian' => [
+      'fontconfig',
+      'libjpeg62-turbo',
+      'libxrender1',
+      'xfonts-75dpi',
+      'xfonts-base',
+    ],
+    'Ubuntu' => [
+      'fontconfig',
+      'libjpeg-turbo8',
+      'libxrender1',
+      'xfonts-75dpi',
+      'xfonts-base',
+    ],
   }
-
-  $wkhtmltox_dependencies = [
-    'xfonts-75dpi',
-    'xfonts-base',
-  ]
 
   archive { "/var/cache/wkhtmltox_${wkhtmltox_version}.deb":
     ensure => present,

--- a/manifests/wkhtmltox.pp
+++ b/manifests/wkhtmltox.pp
@@ -26,7 +26,9 @@ class odoo::wkhtmltox {
     ],
   }
 
-  archive { "/var/cache/wkhtmltox_${wkhtmltox_version}.deb":
+  $wkhtmltox_filename = "/var/cache/wkhtmltox_${wkhtmltox_version}.${facts.get('os.distro.codename')}_${facts.get('architecture')}.deb"
+
+  archive { $wkhtmltox_filename:
     ensure => present,
     user   => 'root',
     group  => 'root',
@@ -40,9 +42,9 @@ class odoo::wkhtmltox {
   package { 'wkhtmltox':
     ensure   => installed,
     provider => 'dpkg',
-    source   => "/var/cache/wkhtmltox_${wkhtmltox_version}.deb",
+    source   => $wkhtmltox_filename,
     require  => [
-      Archive["/var/cache/wkhtmltox_${wkhtmltox_version}.deb"],
+      Archive[$wkhtmltox_filename],
       Package[$wkhtmltox_dependencies],
     ],
   }


### PR DESCRIPTION
The old download URL does not work anymore.  Switch to packages hosted on
GitHub.  They seems to be packaged differently, and require adjustments to the
run-time dependencies.

While here, always use the version of wkhtmltopdf recommended by Odoo for all
versions of Odoo.