### PR TITLE
Fix odoo::database_restore

### DIFF
--- a/files/database-restore.py
+++ b/files/database-restore.py
@@ -1,4 +1,5 @@
+import base64
 import os
 
 odoo.tools.config['list_db'] = True
-odoo.service.db.exp_restore(os.environ['PT_name'], os.environ['PT_filename'], os.environ['PT_copy'].lower() in ('yes', 'true', 't', 'y', '1'))
+odoo.service.db.exp_restore(os.environ['PT_name'], base64.b64encode(open(os.environ['PT_filename'], 'rb').read()), os.environ['PT_copy'].lower() in ('yes', 'true', 't', 'y', '1'))


### PR DESCRIPTION
The odoo.service.db.exp_restore() function expects a base64 encoded
stream of the file to restore, not the filename of the file to restore.