### PR TITLE
Fix fact resolution with Debian system package

### DIFF
--- a/lib/facter/odoo.rb
+++ b/lib/facter/odoo.rb
@@ -24,7 +24,6 @@ def build_odoo_fact
         'full': odoo.release.version,
         'major': parts[0],
         'minor': parts[1],
-        'date': parts[2],
       }
       if len(parts) > 2:
           res['release']['date'] = parts[2]


### PR DESCRIPTION
The Debian package do not have a date component.  The version splitting
took this into account but some reordering of commits have broken this.
