### PR TITLE
Add Bolt tasks to initialize / update odoo databases

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 1.0.0 < 9.0.0"
+      "version_requirement": ">= 1.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-inifile",

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,6 @@
+# Facter < 4 needs lsb-release for os.distro.codename
+if $facts['os']['name'] == 'Ubuntu' and versioncmp($facts['facterversion'], '4.0.0') <= 0 {
+  package { 'lsb-release':
+    ensure => installed,
+  }
+}

--- a/tasks/database_init.json
+++ b/tasks/database_init.json
@@ -1,0 +1,15 @@
+{
+  "description": "Initialize an odoo database",
+  "input_method": "environment",
+  "parameters": {
+    "name": {
+      "description": "Odoo database name",
+      "type": "String[1]"
+    },
+    "unaccent": {
+      "description": "Use the unaccent function provided by the database",
+      "type": "Boolean",
+      "default": true
+    }
+  }
+}

--- a/tasks/database_init.sh
+++ b/tasks/database_init.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+extra_args=""
+
+if [ "${PT_unaccent}" = true ]; then
+  extra_args="${extra_args} --unaccent"
+fi
+
+/usr/bin/odoo --config=/etc/odoo/odoo.conf --no-http --workers=0 --database="${PT_name}" --init=all --without-demo=all --stop-after-init $extra_args

--- a/tasks/database_update.json
+++ b/tasks/database_update.json
@@ -1,0 +1,10 @@
+{
+  "description": "Update an odoo database",
+  "input_method": "environment",
+  "parameters": {
+    "database": {
+      "description": "Odoo database name",
+      "type": "String[1]"
+    }
+  }
+}

--- a/tasks/database_update.sh
+++ b/tasks/database_update.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+/usr/bin/odoo --config=/etc/odoo/odoo.conf --no-http --workers=0 --database="${PT_name}" --update=all --stop-after-init


### PR DESCRIPTION
Compared with the default upstream behavior, this module:
* Don't install demo data when initializing a database;
* Enable unaccent by default when initializing a database (require odoo 15+, and can be disabled using `unaccent=false`);

This PR also include:
* #55 