### PR TITLE
Fix legacy fact

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'puppetlabs_spec_helper', '~> 2.0', :require => false
 gem 'rake', :require => false
 gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-puppetversion = ENV['PUPPET_VERSION'] || '~> 6.0'
+puppetversion = ENV['PUPPET_VERSION'] || '~> 6.29'
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby

--- a/manifests/wkhtmltox.pp
+++ b/manifests/wkhtmltox.pp
@@ -5,7 +5,7 @@ class odoo::wkhtmltox {
   assert_private()
 
   $wkhtmltox_version = '0.12.5'
-  $wkhtmltox_url = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${wkhtmltox_version}/wkhtmltox_${wkhtmltox_version}-1.${facts.get('os.distro.codename')}_${facts.get('architecture')}.deb"
+  $wkhtmltox_url = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${wkhtmltox_version}/wkhtmltox_${wkhtmltox_version}-1.${facts.get('os.distro.codename')}_${facts.get('os.architecture')}.deb"
 
   $wkhtmltox_dependencies = $facts.get('os.name') ? {
     'Debian' => [
@@ -24,7 +24,7 @@ class odoo::wkhtmltox {
     ],
   }
 
-  $wkhtmltox_filename = "/var/cache/wkhtmltox_${wkhtmltox_version}.${facts.get('os.distro.codename')}_${facts.get('architecture')}.deb"
+  $wkhtmltox_filename = "/var/cache/wkhtmltox_${wkhtmltox_version}.${facts.get('os.distro.codename')}_${facts.get('os.architecture')}.deb"
 
   archive { $wkhtmltox_filename:
     ensure => present,


### PR DESCRIPTION
The `architecture` fact is a legacy one and `os.architecture` should be
preferred over it.  Puppet 8 will stop sending legacy facts by default,
so update the module to get rid of this.
