### PR TITLE
Fix `odoo` fact with odoo 16.0

### DIFF
--- a/lib/facter/odoo.rb
+++ b/lib/facter/odoo.rb
@@ -35,7 +35,11 @@ def build_odoo_fact
       res['databases'] = {}
 
       def module_info(addon):
-          info = odoo.modules.load_information_from_description_file(addon)
+          try:
+              info = odoo.modules.get_manifest(addon)
+          except AttributeError:
+              # Odoo 16 deprecated load_information_from_description_file and alias it to get_manifest
+              info = odoo.modules.load_information_from_description_file(addon)
           return {
             'name': info.get('name'),
             'version': info.get('version'),


### PR DESCRIPTION
The load_information_from_description_file() function was renamed to
get_manifest(), see:
https://github.com/odoo/odoo/commit/2e29a9350306fd94fff19bc02821d7e7ab9c6f8b
