### PR TITLE
Fix `odoo::database_restore`

### DIFF
--- a/files/database-restore.py
+++ b/files/database-restore.py
@@ -2,4 +2,4 @@ import base64
 import os
 
 odoo.tools.config['list_db'] = True
-odoo.service.db.exp_restore(os.environ['PT_name'], base64.b64encode(open(os.environ['PT_filename'], 'rb').read()), os.environ['PT_copy'].lower() in ('yes', 'true', 't', 'y', '1'))
+odoo.service.db.restore_db(os.environ['PT_name'], os.environ['PT_filename'], os.environ['PT_copy'].lower() in ('yes', 'true', 't', 'y', '1'))


### PR DESCRIPTION
I suspect functions where renamed at some point or we screwed the hard
way…  The exp_restore function seems to be a wrapper around restore_db
that b64decode the passed data in a temporary file, so use the
restore_db function directly.
