### PR TITLE
Namespace ensure_packages()

### DIFF
--- a/manifests/wkhtmltox.pp
+++ b/manifests/wkhtmltox.pp
@@ -33,7 +33,7 @@ class odoo::wkhtmltox {
     source => $wkhtmltox_url,
   }
 
-  ensure_packages($wkhtmltox_dependencies, { ensure => installed })
+  stdlib::ensure_packages($wkhtmltox_dependencies, { ensure => installed })
 
   package { 'wkhtmltox':
     ensure   => installed,

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The ensure_packages() function is deprecated and we should use
stdlib::ensure_packages() instead.
