### PR TITLE
Fix Debian 10 support

### DIFF
--- a/spec/acceptance/odoo_spec.rb
+++ b/spec/acceptance/odoo_spec.rb
@@ -52,10 +52,6 @@ describe 'odoo class' do
                    },
                  }
 
-                 if $facts.get('os.name') == 'debian' {
-                   class { 'apt::backports':
-                   }
-                 }
                  if $facts.get('os.name') == 'ubuntu' {
                    apt::source { 'ubuntu-universe':
                      location => 'http://archive.ubuntu.com/ubuntu',


### PR DESCRIPTION
Debian 10 does not ship backports anymore.  Not sure why this was here
in the first place.
