### PR TITLE
Update wkhtmltox

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -47,6 +47,7 @@ Configure Odoo
 The following parameters are available in the `odoo` class:
 
 * [`version`](#-odoo--version)
+* [`wkhtmltox_version`](#-odoo--wkhtmltox_version)
 * [`wkhtmltopdf`](#-odoo--wkhtmltopdf)
 * [`manage_package`](#-odoo--manage_package)
 * [`package_name`](#-odoo--package_name)
@@ -118,6 +119,14 @@ The following parameters are available in the `odoo` class:
 Data type: `Enum['10.0', '11.0', '12.0', '13.0', '14.0', '15.0', '16.0', '17.0', 'system']`
 
 The version of odoo to install
+
+Default value: `undef`
+
+##### <a name="-odoo--wkhtmltox_version"></a>`wkhtmltox_version`
+
+Data type: `String[1]`
+
+Version of wkhtmltox to install when wkhtmltopdf is set to wkhtmltox
 
 Default value: `undef`
 

--- a/data/Debian/Ubuntu/20.04.yaml
+++ b/data/Debian/Ubuntu/20.04.yaml
@@ -1,0 +1,2 @@
+---
+odoo::wkhtmltox_version: 0.12.6-1

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,2 @@
+---
+odoo::wkhtmltox_version: 0.12.6.1-3

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,7 @@
 # @summary Configure Odoo
 #
 # @param version The version of odoo to install
+# @param wkhtmltox_version Version of wkhtmltox to install when wkhtmltopdf is set to wkhtmltox
 # @param wkhtmltopdf How to manage wkhtmltopdf
 # @param manage_package Manage the odoo package
 # @param package_name The name of the odoo package
@@ -80,7 +81,9 @@
 # @param limit_request Maximum number of request to be processed per worker
 class odoo (
   Enum['10.0', '11.0', '12.0', '13.0', '14.0', '15.0', '16.0', '17.0', 'system'] $version = undef,
-  Optional[Enum['wkhtmltox']]                            $wkhtmltopdf = undef,
+
+  String[1]                   $wkhtmltox_version = undef,
+  Optional[Enum['wkhtmltox']] $wkhtmltopdf = undef,
 
   Boolean   $manage_package = true,
   String[1] $package_name   = 'odoo',

--- a/manifests/wkhtmltox.pp
+++ b/manifests/wkhtmltox.pp
@@ -4,8 +4,7 @@
 class odoo::wkhtmltox {
   assert_private()
 
-  $wkhtmltox_version = '0.12.5'
-  $wkhtmltox_url = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${wkhtmltox_version}/wkhtmltox_${wkhtmltox_version}-1.${facts.get('os.distro.codename')}_${facts.get('os.architecture')}.deb"
+  $wkhtmltox_url = "https://github.com/wkhtmltopdf/packaging/releases/download/${odoo::wkhtmltox_version}/wkhtmltox_${odoo::wkhtmltox_version}.${facts.get('os.distro.codename')}_${facts.get('os.architecture')}.deb"
 
   $wkhtmltox_dependencies = $facts.get('os.name') ? {
     'Debian' => [
@@ -24,7 +23,7 @@ class odoo::wkhtmltox {
     ],
   }
 
-  $wkhtmltox_filename = "/var/cache/wkhtmltox_${wkhtmltox_version}.${facts.get('os.distro.codename')}_${facts.get('os.architecture')}.deb"
+  $wkhtmltox_filename = "/var/cache/wkhtmltox_${odoo::wkhtmltox_version}.${facts.get('os.distro.codename')}_${facts.get('os.architecture')}.deb"
 
   archive { $wkhtmltox_filename:
     ensure => present,
@@ -33,7 +32,7 @@ class odoo::wkhtmltox {
     source => $wkhtmltox_url,
   }
 
-  stdlib::ensure_packages($wkhtmltox_dependencies, { ensure => installed })
+  stdlib::ensure_packages($wkhtmltox_dependencies, { ensure => installed, require => Class['odoo::dependencies'] })
 
   package { 'wkhtmltox':
     ensure   => installed,

--- a/spec/acceptance/odoo_spec.rb
+++ b/spec/acceptance/odoo_spec.rb
@@ -42,7 +42,8 @@ describe 'odoo class' do
                  }
 
                  class { 'odoo':
-                   version => '#{version}'
+                   version     => '#{version}',
+                   wkhtmltopdf => 'wkhtmltox',
                  }
                MANIFEST
              else
@@ -68,7 +69,8 @@ describe 'odoo class' do
                  }
 
                  class { 'odoo':
-                   version => '#{version}'
+                   version     => '#{version}',
+                   wkhtmltopdf => 'wkhtmltox',
                  }
 
                  Class['apt::update']


### PR DESCRIPTION
Upstream has stopped maintaining this fork, but they had created a
second repo where more recent packages are available for recent versions
of Debian.

Switch to this legacy archive to unbreak pdf generation with recent
versions of Debian.
