### PR TITLE
Switch to another source for wkhtmltopdf

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -128,7 +128,7 @@ Data type: `String[1]`
 
 Version of wkhtmltox to install when wkhtmltopdf is set to wkhtmltox
 
-Default value: `undef`
+Default value: `'0.12.6.1'`
 
 ##### <a name="-odoo--wkhtmltopdf"></a>`wkhtmltopdf`
 

--- a/data/Debian/Ubuntu/20.04.yaml
+++ b/data/Debian/Ubuntu/20.04.yaml
@@ -1,2 +1,0 @@
----
-odoo::wkhtmltox_version: 0.12.6-1

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,2 +1,0 @@
----
-odoo::wkhtmltox_version: 0.12.6.1-3

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,7 +82,7 @@
 class odoo (
   Enum['10.0', '11.0', '12.0', '13.0', '14.0', '15.0', '16.0', '17.0', '18.0', 'system'] $version = undef,
 
-  String[1]                   $wkhtmltox_version = undef,
+  String[1]                   $wkhtmltox_version = '0.12.6.1',
   Optional[Enum['wkhtmltox']] $wkhtmltopdf = undef,
 
   Boolean   $manage_package = true,

--- a/manifests/wkhtmltox.pp
+++ b/manifests/wkhtmltox.pp
@@ -4,7 +4,7 @@
 class odoo::wkhtmltox {
   assert_private()
 
-  $wkhtmltox_url = "https://github.com/wkhtmltopdf/packaging/releases/download/${odoo::wkhtmltox_version}/wkhtmltox_${odoo::wkhtmltox_version}.${facts.get('os.distro.codename')}_${facts.get('os.architecture')}.deb"
+  $wkhtmltox_url = "https://github.com/newinnovations/wkhtml-packaging/releases/download/v${odoo::wkhtmltox_version}/wkhtmltox_${odoo::wkhtmltox_version}-${facts.get('os.distro.codename')}_${facts.get('os.architecture')}.deb"
 
   $wkhtmltox_dependencies = $facts.get('os.name') ? {
     'Debian' => [


### PR DESCRIPTION
The upstream project has been archived and packages for new operating
systems will not happen there.  The project has a bunch of forks, and it
looks like Martin van der Werff (@newinnovations) did a great work to
continue providing wkhtmltopdf, so use their packages.
