### PR TITLE
Fix regular expression escaping

### DIFF
--- a/lib/facter/odoo.rb
+++ b/lib/facter/odoo.rb
@@ -53,7 +53,7 @@ def build_odoo_fact
               env = odoo.api.Environment(cr, uid, ctx)
 
               res['databases'][dbname] = {}
-              regex = re.compile('\\A__\\w*__\\Z')
+              regex = re.compile(r'\\A__\\w*__\\Z')
               res['databases'][dbname]['addons'] = {}
               for addon in dir(odoo.addons):
                   if not regex.match(addon):


### PR DESCRIPTION
When passing the regular expression to Python, we escape the `\` char in
the Ruby string so that Python sees `'\A__\w+__\Z'`, but this raw string
produce a warning when running in development mode.

We need to tell Python to consider this as a raw string so that it does
not complain.

This fix the warning:
```
<string>:37: DeprecationWarning: invalid escape sequence \A
```
